### PR TITLE
Fix single digit values are misinterpreted #4

### DIFF
--- a/grafista/application/main.py
+++ b/grafista/application/main.py
@@ -54,9 +54,7 @@ def series_view(name):
     request_format = request.args.get('format')
     if request_format and request_format == 'json':
         samples_query = Samples.select().where(Samples.serie == serie.id)
-        samples = []
-        for s in samples_query:
-            samples.append((s.timestamp, s.value))
+        samples = [(s.timestamp, int(s.value)) for s in samples_query]
         return jsonify(samples=samples)
     else:
         return render_template('series_view.pug', serie=serie)


### PR DESCRIPTION
The json file created by the "web-server" was always a string, which leads to some funky ordering (e.g., 9 > 50).

We can use the "value_type" from the database instead, if we are to support floats. But that should be in the series table, not in the sample in my opinion. So I think this can be tackled separatedly