### PR TITLE
Fix bug of showing the last value of first graph only

### DIFF
--- a/grafista/application/models.py
+++ b/grafista/application/models.py
@@ -49,7 +49,7 @@ class Series(BaseModel):
     @property
     def latest_sample(self):
         """The latest sample for a serie, used to show values in the interface"""
-        sample = Samples.select().order_by(Samples.timestamp.desc()).get()
+        sample = Samples.select().where(Samples.serie_id == self.id).order_by(Samples.timestamp.desc()).get()
         return sample
 
     def __unicode__(self):


### PR DESCRIPTION
Before:
![1712](https://cloud.githubusercontent.com/assets/843498/22527981/98b56f68-e8d1-11e6-88ee-d9311a5487cc.jpg)

After the fix:
![fixed](https://cloud.githubusercontent.com/assets/843498/22527987/9da2af4a-e8d1-11e6-8fcf-65e75f49749d.jpg)

This also fix the same issue for the individual graphs.
